### PR TITLE
filename fix for case-sensitive file systems

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Fooidge"
   ],
   "description": "JS library to generate random pleasing colors/color schemes",
-  "main": "please.js",
+  "main": "Please.js",
   "keywords": [
     "color",
     "scheme",


### PR DESCRIPTION
Bower would automatically add path/please.js as a script source when the filename would be path/Please.js

This caused bower to point at an inexistent file on a case-sensitive file system.
