### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#PleaseJS
+# PleaseJS
 
 www.checkman.io/please
 
@@ -21,7 +21,7 @@ Please.make_scheme(
 });
 ```
 
-##Core
+## Core
 
 ### make_color
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
